### PR TITLE
Convert input string into UTF-8 bytes to allow non-ASCII characters like emoji

### DIFF
--- a/qrencode-tests.el
+++ b/qrencode-tests.el
@@ -353,11 +353,15 @@
         (message "zbarimg not found.  Not running all tests!")
       (let ((tmpfile (make-temp-file "qr" nil ".pbm")))
         (cl-loop for input across
-                 ;; zbarimg doesn't handle UTF-8 well, so can't test Unicode here :(
                  ["hello"
                   "https://github.com/ruediger/qrencode-el"
                   "hellohellohellohellohellohellohellohellohellohellohellohellohellohellohellohellohellohellohellohellohellohellohellohellohellohellohellohellohellohello"
                   "qrqrqrqrqrqrqrqrqrqrqrqrqrqrqrqrqrqrqrqrqrqrqrqrqrqrqrqrqrqrqrqrqrqrqrqrqrqrqrqrqrqrqrqrqrqrqrqrqrqrqrqrqrqrqrqrqrqrqrqrqrqrqrqrqrqrqrqrqrqrqrqrqrqrqrqrqrqrqrqrqrqrqrqrqrqrqrqrqrqrqrqrqrqrqrqrqrqrqrqrqrqrqrqrqrqrqrqrqrqrqrqrqrqrqrqrqrqrqrqrqrqrqrqrqrqrqrqr"
+
+                  ;; escaped Unicode characters
+                  "\U0001f600\U0001f680\u3042"
+                  ;; raw UTF-8 characters
+                  "😸🚗愛"
                   ]
                  do (with-temp-file tmpfile
                       (insert (qrencode-format-as-netpbm (qrencode input nil nil 'return-raw))))

--- a/qrencode.el
+++ b/qrencode.el
@@ -870,17 +870,19 @@ is `byte'.  If RETURN-RAW is set a raw vector version of the
 QRCode is returned instead of a formatted string."
   ;; Following Section 7.1 from ISO/IEC 18004 2015
 
-  (let (version data qr function-pattern datamask)
+  (let (version raw-bytes data qr function-pattern datamask)
     ;; Step 1: Analyse data
     ;; TODO(#11): find suitable mode. For now we only support byte
     (setq mode (or mode 'byte))
+    ;; Convert Emacs internal encoded characters into raw UTF-8 bytes
+    (setq raw-bytes (encode-coding-string s 'utf-8))
     ;; Find the version with the highest error correction to fit the data
-    (pcase-let ((`(,ver . ,ec) (qrencode--find-version (length s) mode errcorr)))
+    (pcase-let ((`(,ver . ,ec) (qrencode--find-version (length raw-bytes) mode errcorr)))
       (setq version ver
             errcorr ec))
 
     ;; Step 2: Encode data
-    (setq data (qrencode--encode-byte s version))
+    (setq data (qrencode--encode-byte raw-bytes version))
     ;; Add padding
     (let* ((size-table (aref qrencode--size-table (1- version)))
            (qrlen (car size-table))


### PR DESCRIPTION
This PR allows non-ASCII characters like emoji for input strings.