### PR TITLE
Set line-spacing after enabling major mode

### DIFF
--- a/qrencode.el
+++ b/qrencode.el
@@ -1065,8 +1065,8 @@ Commands:
       (with-current-buffer buf
         (let ((inhibit-read-only t))
           (erase-buffer)
-          (setq-local line-spacing nil)  ; ensure no line spacing
           (qrencode-mode)
+          (setq-local line-spacing nil)  ; ensure no line spacing
           (setq-local qrencode--raw-qr (qrencode s nil nil 'return-raw))
           (insert (propertize (qrencode-format qrencode--raw-qr) 'face 'qrencode-face))
           (insert "\nEncoded Text:\n" s)


### PR DESCRIPTION
The major mode kills local variables.